### PR TITLE
Update epanet.m

### DIFF
--- a/epanet.m
+++ b/epanet.m
@@ -2134,7 +2134,7 @@ classdef epanet <handle
                 NodeNumDemandC=obj.getNodeDemandCategoriesNumber;
                 for i=1:obj.getNodeJunctionCount
                     for u=1:NodeNumDemandC(i)
-                        [obj.Errcode] = ENsetbasedemand(i, NodeNumDemandC(u), value{NodeNumDemandC(u)}(i),obj.LibEPANET);
+                        [obj.Errcode] = ENsetbasedemand(i, u, value{u}(i),obj.LibEPANET);
                     end
                 end
             else %version epanet20012


### PR DESCRIPTION
The Input for ENsetbasedemand is (index, demandIdx, value). Here, "u" corresponds to the demandIdx which is already found by evaluating u=1:NodeNumDemandC(i). 

Try for example the testnetwork 'networks/BWSN1_Ostfeld2008.inp' where junction_45 (node 46) has two different demands/patterns assigned. In that case NodeNumDemandC(1 and 2) will be 1, since they point to Node 1 and Node 2.