### PR TITLE
fix  bug in setControls function when the set pump speed as a specific speed

### DIFF
--- a/epanet.m
+++ b/epanet.m
@@ -11308,10 +11308,12 @@ function setControlFunction(obj, index, value)
         if strcmpi(splitControl(3), 'CLOSE')
             controlSettingValue = 0;
         else
-            controlSettingValue = splitControl(3);
+            % control setting Value (type should be int) for pump or valve
+            controlSettingValue = str2num(splitControl{3});
         end
     end
-    linkIndex = obj.getLinkIndex(splitControl(2));
+    linkIndexArray = obj.getLinkIndex;
+    linkIndex = linkIndexArray(str2num(splitControl{2}));
     if linkIndex==0
         warning('Wrong link ID. Please change your control.')
     end

--- a/epanet.m
+++ b/epanet.m
@@ -11312,9 +11312,8 @@ function setControlFunction(obj, index, value)
             controlSettingValue = str2num(splitControl{3});
         end
     end
-    linkIndexArray = obj.getLinkIndex;
-    linkIndex = linkIndexArray(str2num(splitControl{2}));
-    if linkIndex==0
+    linkIndex = obj.getLinkIndex(splitControl(2));
+    if ~linkIndex
         warning('Wrong link ID. Please change your control.')
     end
     switch upper(splitControl{4})


### PR DESCRIPTION
Fix a bug in setControls function when setting pump speed as a specific speed e.g'LINK 9 1.2 AT TIME 252000' which means that we set the pump speed as 1.2 at time 252000.

1.  original controlSettingValue is a string, not an int value.
2.  original LinkIndex is a string, not an int value.