### PR TITLE
runMSXexe change

### DIFF
--- a/epanet.m
+++ b/epanet.m
@@ -10974,7 +10974,7 @@ function [status,result] = runMSXexe(obj, rptfile, varargin)
         [~,lpwd]=system(['cmd /c for %A in ("',obj.MSXLibEPANETPath,'") do @echo %~sA']);
         libPwd=regexp(lpwd,'\s','split');
         if nargin<3
-            r = sprintf('%s\\epanetmsx.exe %s %s %s',libPwd{1},inpfile,obj.MSXTempFile,rptfile);
+            r = sprintf('%s\\epanetmsx.exe "%s" "%s" "%s"',libPwd{1},inpfile,obj.MSXTempFile,rptfile);
         else
             binfile=varargin{1};
             r = sprintf('%s\\epanetmsx.exe %s %s %s %s',libPwd{1},inpfile,obj.MSXTempFile,rptfile,binfile);
@@ -10982,7 +10982,7 @@ function [status,result] = runMSXexe(obj, rptfile, varargin)
     end
     if isunix
         if nargin<3
-            r = sprintf('%sepanetmsx %s %s %s',obj.MSXLibEPANETPath,inpfile,obj.MSXTempFile,rptfile);
+            r = sprintf('%sepanetmsx "%s" "%s" "%s"',obj.MSXLibEPANETPath,inpfile,obj.MSXTempFile,rptfile);
         else
            binfile=varargin{1};
             r = sprintf('%sepanetmsx %s %s %s %s',obj.MSXLibEPANETPath,inpfile,obj.MSXTempFile,rptfile,binfile);


### PR DESCRIPTION
I had troubles with 'runMSXexe'  in Windows and on a Linux based server  (both running Matlab 2018a) . Including quotation marks for the MSXlibEPANETpath, .inp file and MSXTempFile lead to a functioning system call (line 10991). I'm guessing the same has to be done with line 10980 and 10988.